### PR TITLE
un-disable IP forwarding

### DIFF
--- a/roles/jupyterhub/tasks/docker.yml
+++ b/roles/jupyterhub/tasks/docker.yml
@@ -30,12 +30,6 @@
   sudo: yes
   register: dockerconf
 
-# This *shouldn't* be necessary because of the DOCKER_OPTS we set.
-# Just for good measure, though.
-- name: disable IP forwarding
-  shell: echo 0 > /proc/sys/net/ipv4/ip_forward
-  sudo: yes
-
 - name: restart docker
   service: name=docker state=restarted
   sudo: yes


### PR DESCRIPTION
We don't want to disable IP forwarding. This is reflected properly in the Docker settings (just `--icc=false`), but this iptables setting needed taking off.
