### PR TITLE
allow Hub to be restarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ To deploy the proxy server:
 ./script/deploy_proxy
 ```
 
+Required variables in secrets.yml (or secrets.vault.yml):
+
+- ssl_key: the SSL key
+- ssl_cert: the SSL certificate
+
 ## JupyterHub
 
 To deploy JupyterHub:
@@ -27,6 +32,11 @@ To deploy JupyterHub:
 ```
 ./script/deploy
 ```
+
+Required variables in secrets.yml (or secrets.vault.yml):
+
+- configproxy_auth_token (a smallish random string - `openssl rand -hex 16`)
+- cookie_secret (a large-ish random hex string - (`openssl rand -hex 2048`))
 
 Note that this will stop JupyterHub if it is currently running -- so don't run
 this when people might be using the hub!

--- a/roles/jupyterhub/tasks/main.yml
+++ b/roles/jupyterhub/tasks/main.yml
@@ -43,6 +43,9 @@
   tags:
     - docker-rebuild
 
+- name: create jupyterhub.sqlite
+  file: path=/srv/jupyterhub/jupyterhub.sqlite state=touch mode=0600
+
 - name: launch jupyterhub
   docker:
     state: running
@@ -54,8 +57,11 @@
       GITHUB_CLIENT_ID: "{{ github_client_id }}"
       GITHUB_CLIENT_SECRET: "{{ github_client_secret }}"
       OAUTH_CALLBACK_URL: "{{ oauth_callback_url }}"
+      JPY_COOKIE_SECRET: "{{ cookie_secret }}"
+      CONFIGPROXY_AUTH_TOKEN: "{{ configproxy_auth_token }}"
     volumes:
         - /var/run/docker.sock:/docker.sock
         - /var/run/restuser.sock:/restuser.sock
+        - /srv/jupyterhub/jupyterhub.sqlite:/srv/oauthenticator/jupyterhub.sqlite
   tags:
     - docker-rebuild


### PR DESCRIPTION
by loading cookie_secret and auth tokens from secrets and mounting jupyterhub.sqlite on the host.

The one thing that's a bit weird is that jupyterhub.sqlite is in /srv/oauthenticator on the container, since that's the CWD. It may make sense to specify this explicitly in the jupyterhub_config.py, with:

```
c.JupyterHub.db_file='/path/to/jupyterhub.sqlite'
```
