### PR TITLE
Consolidate docker images into one place

### DIFF
--- a/roles/jupyterhub/files/Dockerfile
+++ b/roles/jupyterhub/files/Dockerfile
@@ -1,1 +1,0 @@
-from jhamrick/jupyterhub

--- a/roles/jupyterhub/files/Dockerfile_jupyterhub
+++ b/roles/jupyterhub/files/Dockerfile_jupyterhub
@@ -1,0 +1,25 @@
+FROM jupyter/jupyterhub
+
+MAINTAINER Jessica Hamrick <jhamrick@berkeley.edu>
+
+# Install dockerspawner and oauthenticator
+RUN pip3 install docker-py
+RUN pip3 install git+git://github.com/jupyter/dockerspawner.git
+RUN pip3 install git+git://github.com/jupyter/oauthenticator.git
+
+# Add variable to allow connecting to the docker host
+ENV DOCKER_HOST unix://docker.sock
+
+# Create oauthenticator directory -- this is where we'll put the userlist later
+RUN mkdir /srv/oauthenticator
+ENV OAUTHENTICATOR_DIR /srv/oauthenticator
+RUN chmod 700 /srv/oauthenticator
+
+# install docker_oauth
+ADD https://raw.githubusercontent.com/jhamrick/docker-oauthenticator/master/docker_oauth.py /srv/oauthenticator/docker_oauth.py
+
+# add the userlist
+ADD userlist /srv/oauthenticator/userlist
+
+# set working directory to the jupyterhub directory
+WORKDIR /srv/jupyterhub

--- a/roles/jupyterhub/files/Dockerfile_systemuser
+++ b/roles/jupyterhub/files/Dockerfile_systemuser
@@ -1,0 +1,4 @@
+FROM jupyter/systemuser
+
+# Install nbgrader
+RUN pip install git+git://github.com/jupyter/nbgrader.git

--- a/roles/jupyterhub/files/jupyterhub_config.py
+++ b/roles/jupyterhub/files/jupyterhub_config.py
@@ -1,0 +1,39 @@
+# Configuration file for Jupyter Hub
+c = get_config()
+
+import os
+import sys
+
+# Base configuration
+c.JupyterHub.log_level = 10
+c.JupyterHub.admin_users = admin = set()
+c.JupyterHub.db_url = 'sqlite:////srv/jupyterhub_db/jupyterhub.sqlite'
+
+# Configure the authenticator
+c.JupyterHub.authenticator_class = 'docker_oauth.DockerOAuthenticator'
+c.DockerOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
+c.DockerOAuthenticator.create_system_users = True
+c.Authenticator.whitelist = whitelist = set()
+
+# Configure the spawner
+c.JupyterHub.spawner_class = 'dockerspawner.SystemUserSpawner'
+c.SystemUserSpawner.container_image = 'compmodels/systemuser'
+
+# The docker instances need access to the Hub, so the default loopback port
+# doesn't work:
+from IPython.utils.localinterfaces import public_ips
+c.JupyterHub.hub_ip = public_ips()[0]
+
+# Add users to the admin list, the whitelist, and also record their user ids
+root = os.environ.get('OAUTHENTICATOR_DIR', os.path.dirname(__file__))
+sys.path.insert(0, root)
+
+with open(os.path.join(root, 'userlist')) as f:
+    for line in f:
+        if line.isspace():
+            continue
+        parts = line.split()
+        name = parts[0]
+        whitelist.add(name)
+        if len(parts) > 1 and parts[1] == 'admin':
+            admin.add(name)

--- a/roles/jupyterhub/tasks/docker-build.yml
+++ b/roles/jupyterhub/tasks/docker-build.yml
@@ -2,8 +2,8 @@
 - name: pull jupyterhub service images
   command: docker pull {{ item }}
   with_items:
-  - jhamrick/systemuser
-  - jhamrick/jupyterhub
+  - jupyter/systemuser
+  - jupyter/jupyterhub
   sudo: yes
   tags:
     - docker-rebuild
@@ -16,8 +16,16 @@
 
 - name: copy the Dockerfile to the jupyterhub directory
   copy:
-    src: Dockerfile
+    src: Dockerfile_jupyterhub
     dest: /srv/jupyterhub/Dockerfile
+  sudo: yes
+  tags:
+    - docker-rebuild
+
+- name: copy jupyterhub_config.py to the jupyterhub directory
+  copy:
+    src: jupyterhub_config.py
+    dest: /srv/jupyterhub/jupyterhub_config.py
   sudo: yes
   tags:
     - docker-rebuild
@@ -28,11 +36,33 @@
   tags:
     - docker-rebuild
 
-- name: build jhamrick/compmodels-jupyterhub:deploy image
+- name: build compmodels/jupyterhub image
   docker_image:
     path: /srv/jupyterhub
-    name: jhamrick/compmodels-jupyterhub
-    tag: deploy
+    name: compmodels/jupyterhub
+    state: build
+  sudo: yes
+  tags:
+    - docker-rebuild
+
+- name: create the systemuser directory
+  file: path=/srv/systemuser state=directory
+  sudo: yes
+  tags:
+    - docker-rebuild
+
+- name: copy the Dockerfile to the systemuser directory
+  copy:
+    src: Dockerfile_systemuser
+    dest: /srv/systemuser/Dockerfile
+  sudo: yes
+  tags:
+    - docker-rebuild
+
+- name: build compmodels/systemuser image
+  docker_image:
+    path: /srv/systemuser
+    name: compmodels/systemuser
     state: build
   sudo: yes
   tags:

--- a/roles/jupyterhub/tasks/main.yml
+++ b/roles/jupyterhub/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: launch jupyterhub
   docker:
     state: running
-    image: jhamrick/compmodels-jupyterhub:deploy
+    image: compmodels/jupyterhub
     detach: true
     net: host
     name: jupyterhub


### PR DESCRIPTION
This is consolidating https://github.com/compmodels/jupyterhub and https://github.com/compmodels/systemuser into the deploy setup, so that way there doesn't need to be a two step process of building docker images. I will remove the docker images from docker hub; I won't remove the repositories but will update them so they point here now.
