### PR TITLE
Cleanup docker

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -100,7 +100,7 @@
     - swarm
 
 - name: remove docker containers
-  shell: docker rm $(docker ps -a -q) || true
+  shell: docker rm -v $(docker ps -a -q) || true
   tags:
     - docker-rebuild
     - swarm

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -107,4 +107,3 @@
 
 - cron: name="docker cleanup" minute=15
         user="root" job="/usr/bin/docker rmi $(/usr/bin/docker images -q --filter 'dangling=true')"
-        cron_file=ansible_docker-cleanup

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -104,3 +104,7 @@
   tags:
     - docker-rebuild
     - swarm
+
+- cron: name="docker cleanup" minute=15
+        user="root" job="/usr/bin/docker rmi $(/usr/bin/docker images -q --filter 'dangling=true')"
+        cron_file=ansible_docker-cleanup


### PR DESCRIPTION
Removes volumes when removing old containers. This ensures that the `vfs`/`volumes` portion of `/var/lib/docker` doesn't stick around after.

Removes untagged Docker images.
