### PR TITLE
Run statistics and culling scripts in docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,18 @@ Swarm itself also runs in a docker container, so you can get the logs with `dock
 Each docker container started through swarm is allocated 1GB of memory (currently there is no limit on CPU, but if a problem arises, we can institute one as well).
 Each node server has 32GB of memory, meaning that we can run about 31*7=217 containers at once.
 We actually have slightly more users than that, so we've set up a script that runs every hour and shuts down user containers if they haven't been accessed in 24 hours.
-The script can be run as follows:
-
-```
-cd /root/cull
-export JPY_API_TOKEN=`cat ../stats/jpy_api_token`
-python3 ./cull_idle_servers.py --timeout=86400 --cull_every=3600 --log_file_prefix=cull.log
-```
-
-You can background the process by pressing `Ctrl-z` and then running the command `bg`. Logs will go into the `cull.log` file.
+The script runs in a docker container called `cull`, so logs can be accessed via `docker logs cull`.
 
 Note: there is currently a bug in JupyterHub that causes the culling script to encounter a bunch of timeout errors because each server takes several seconds to shutdown.
 This has been fixed in JupyterHub, but we haven't updated to the new version yet because it will cause a service interruption.
 In the meantime, the errors are mostly harmless; the user servers still end up getting shutdown.
+
+### Activity statistics
+
+There is another service that runs and periodically checks which users have been active recently.
+It then saves that information into a sqlite database, which can subsequently be downloaded and analyzed.
+This script runs in a docker container called `stats`, so logs can be accessed via `docker logs stats`.
+The sqlite database is saved to `/srv/stats/db/activity.sqlite`.
 
 ## Node servers
 

--- a/roles/jupyterhub_host/files/Dockerfile_cull
+++ b/roles/jupyterhub_host/files/Dockerfile_cull
@@ -1,0 +1,10 @@
+FROM python:3
+
+RUN pip install tornado python-dateutil
+
+RUN mkdir /srv/cull
+WORKDIR /srv/cull
+ADD https://raw.githubusercontent.com/jupyter/jupyterhub/master/examples/cull-idle/cull_idle_servers.py /srv/cull/cull_idle_servers.py
+
+ENTRYPOINT ["python", "cull_idle_servers.py"]
+CMD ["--timeout=86400", "--cull_every=3600"]

--- a/roles/jupyterhub_host/files/Dockerfile_stats
+++ b/roles/jupyterhub_host/files/Dockerfile_stats
@@ -8,4 +8,4 @@ ADD https://raw.githubusercontent.com/minrk/log_jupyterhub_activity/master/log_a
 
 RUN mkdir /srv/stats/db
 ENTRYPOINT ["python", "log_activity"]
-CMD ["--file", "db/activity.sqlite"]
+CMD ["--file=db/activity.sqlite"]

--- a/roles/jupyterhub_host/files/Dockerfile_stats
+++ b/roles/jupyterhub_host/files/Dockerfile_stats
@@ -4,8 +4,8 @@ RUN pip install requests python-dateutil
 
 RUN mkdir /srv/stats
 WORKDIR /srv/stats
-ADD https://raw.githubusercontent.com/minrk/log_jupyterhub_activity/master/log_activity /srv/stats/log_activity
+ADD https://raw.githubusercontent.com/minrk/log_jupyterhub_activity/master/log_activity /srv/stats/log_activity.py
 
 RUN mkdir /srv/stats/db
-ENTRYPOINT ["python", "log_activity"]
+ENTRYPOINT ["python", "log_activity.py"]
 CMD ["--file=db/activity.sqlite"]

--- a/roles/jupyterhub_host/files/Dockerfile_stats
+++ b/roles/jupyterhub_host/files/Dockerfile_stats
@@ -1,0 +1,11 @@
+FROM python:3
+
+RUN pip install requests python-dateutil
+
+RUN mkdir /srv/stats
+WORKDIR /srv/stats
+ADD https://raw.githubusercontent.com/minrk/log_jupyterhub_activity/master/log_activity /srv/stats/log_activity
+
+RUN mkdir /srv/stats/db
+ENTRYPOINT ["python", "log_activity"]
+CMD ["--file", "db/activity.sqlite"]

--- a/roles/jupyterhub_host/tasks/cull.yml
+++ b/roles/jupyterhub_host/tasks/cull.yml
@@ -1,0 +1,48 @@
+---
+- name: stop and remove cull container
+  docker:
+    state: absent
+    image: compmodels/cull
+    name: cull
+  sudo: yes
+  tags:
+    - cull
+    - docker-rebuild
+
+- name: create the /srv/cull directory
+  file: path=/srv/cull state=directory
+  sudo: yes
+  tags:
+    - cull
+    - docker-rebuild
+
+- name: copy the Dockerfile to /srv/cull
+  copy: src=Dockerfile_cull dest=/srv/cull/Dockerfile
+  sudo: yes
+  tags:
+    - cull
+    - docker-rebuild
+
+- name: build compmodels/cull image
+  docker_image:
+    path: /srv/cull
+    name: compmodels/cull
+    state: build
+  sudo: yes
+  tags:
+    - cull
+    - docker-rebuild
+
+- name: launch cull
+  docker:
+    state: running
+    image: compmodels/cull
+    detach: true
+    name: cull
+    net: host
+    env:
+      JPY_API_TOKEN: "{{ jpy_api_token.stdout }}"
+  sudo: yes
+  tags:
+    - cull
+    - docker-rebuild

--- a/roles/jupyterhub_host/tasks/docker-build.yml
+++ b/roles/jupyterhub_host/tasks/docker-build.yml
@@ -1,4 +1,16 @@
 ---
+- name: create the jupyterhub_db directory
+  file: path=/srv/jupyterhub_db state=directory
+  sudo: yes
+  tags:
+    - docker-rebuild
+
+- name: create jupyterhub.sqlite
+  file: path=/srv/jupyterhub_db/jupyterhub.sqlite state=touch mode=0600
+  sudo: yes
+  tags:
+    - docker-rebuild
+
 - name: create the jupyterhub directory
   file: path=/srv/jupyterhub state=directory
   sudo: yes

--- a/roles/jupyterhub_host/tasks/main.yml
+++ b/roles/jupyterhub_host/tasks/main.yml
@@ -7,9 +7,6 @@
 - include: accounts.yml
 - include: swarm.yml
 
-- name: create jupyterhub.sqlite
-  file: path=/srv/jupyterhub/jupyterhub.sqlite state=touch mode=0600
-
 - name: launch jupyterhub
   docker:
     state: running

--- a/roles/jupyterhub_host/tasks/main.yml
+++ b/roles/jupyterhub_host/tasks/main.yml
@@ -37,6 +37,8 @@
   sudo: yes
   tags:
     - stats
+    - cull
     - docker-rebuild
 
 - include: stats.yml
+- include: cull.yml

--- a/roles/jupyterhub_host/tasks/main.yml
+++ b/roles/jupyterhub_host/tasks/main.yml
@@ -30,3 +30,13 @@
         - "{{ docker_tls_path }}:{{ docker_tls_path }}"
   tags:
     - docker-rebuild
+
+- name: get a jupyterhub api token
+  command: docker exec jupyterhub jupyterhub token root
+  register: jpy_api_token
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild
+
+- include: stats.yml

--- a/roles/jupyterhub_host/tasks/main.yml
+++ b/roles/jupyterhub_host/tasks/main.yml
@@ -29,7 +29,7 @@
     - docker-rebuild
 
 - name: get a jupyterhub api token
-  command: docker exec jupyterhub jupyterhub token root
+  command: docker exec jupyterhub jupyterhub token {{ instructors[0] }}
   register: jpy_api_token
   sudo: yes
   tags:

--- a/roles/jupyterhub_host/tasks/main.yml
+++ b/roles/jupyterhub_host/tasks/main.yml
@@ -29,7 +29,7 @@
     - docker-rebuild
 
 - name: get a jupyterhub api token
-  command: docker exec jupyterhub jupyterhub token {{ instructors[0] }}
+  command: docker exec jupyterhub jupyterhub token -f /srv/jupyterhub/jupyterhub_config.py {{ instructors[0] }}
   register: jpy_api_token
   sudo: yes
   tags:

--- a/roles/jupyterhub_host/tasks/stats.yml
+++ b/roles/jupyterhub_host/tasks/stats.yml
@@ -1,0 +1,57 @@
+---
+- name: stop and remove stats container
+  docker:
+    state: absent
+    image: compmodels/stats
+    name: stats
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild
+
+- name: create the /srv/stats directory
+  file: path=/srv/stats state=directory
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild
+
+- name: create the /srv/stats/db directory
+  file: path=/srv/stats/db state=directory
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild
+
+- name: copy the Dockerfile to /srv/stats
+  copy: src=Dockerfile_stats dest=/srv/stats/Dockerfile
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild
+
+- name: build compmodels/stats image
+  docker_image:
+    path: /srv/stats
+    name: compmodels/stats
+    state: build
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild
+
+- name: launch stats
+  docker:
+    state: running
+    image: compmodels/stats
+    detach: true
+    name: stats
+    net: host
+    env:
+      JPY_API_TOKEN: "{{ jpy_api_token.stdout }}"
+    volumes:
+        - /srv/stats/db:/srv/stats/db
+  sudo: yes
+  tags:
+    - stats
+    - docker-rebuild


### PR DESCRIPTION
Fixes #19 and also puts the culling script in a docker container.

Doesn't quite work yet, though, as jupyterhub seems to dislike the token that's generated.
