### PR TITLE
Upgrade SSL/TLS settings

### DIFF
--- a/roles/proxy/templates/nginx.conf.j2
+++ b/roles/proxy/templates/nginx.conf.j2
@@ -27,10 +27,16 @@ http {
         ssl on;
         ssl_certificate {{ ssl_cert_path }};
         ssl_certificate_key {{ ssl_key_path }};
-        ssl_session_timeout 5m;
-        ssl_protocols SSLv2 SSLv3 TLSv1;
-        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        ssl_ciphers "AES128+EECDH:AES128+EDH";
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:10m;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+        add_header X-Content-Type-Options nosniff;
+        ssl_stapling on; # Requires nginx >= 1.3.7
+        ssl_stapling_verify on; # Requires nginx => 1.3.7
+        resolver_timeout 5s;
 
         # Expose logs to "docker logs".
         # See https://github.com/nginxinc/docker-nginx/blob/master/Dockerfile#L12-L14


### PR DESCRIPTION
As suggested by @minrk for https://github.com/jupyter/tmpnb-deploy/pull/11, this makes sure we're strict about our use of SSL/TLS (primarily to mitigate POODLE).
